### PR TITLE
Add voxelyo to Photo & Image Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ powered by ada. | Supporting better health outcomes and clinical excellence with
 | [jpghd](http://jpghd.com) | JPGHD - Lossless Restoration of Old Photos With AI. | Using 2022 cutting-edge AI models for lossless restoration of old photos (supports old, scratched photo restoration, colorization, and Magic Photo). | :grey_question: |
 | [paintbytext](https://paintbytext.chat) | Paint by Text. | paintbytext - Edit your photos using written instructions, with the help of an AI. | :white_check_mark: |
 | [InstructPix2Pix](https://www.timothybrooks.com/instruct-pix2pix) | We propose a method for editing images from human instructions: given an input image and a written instruction that tells the model what to do, our model follows these instructions to edit the image. To obtain training data for this problem, we combine the knowledge of two large pre-trained models to generate a large dataset of image editing examples. | . | :white_check_mark: |
+| [voxelyo](https://voxelyo.com) | voxelyo - AI Photo Enhancement for Airbnb, Vrbo & Real Estate Listings. | AI auto-enhance and virtual twilight/day-to-dusk conversion for short-term rental and real-estate listing photos. | :grey_question: |
 
 
 ### Plugins & Extensions


### PR DESCRIPTION
Adds voxelyo (https://voxelyo.com) to the Photo & Image Editing section.

Disclosure: I'm the creator/maintainer of voxelyo.

- AI photo enhancement for Airbnb, Vrbo, and real-estate listing photos — auto-enhance plus virtual twilight/day-to-dusk conversion.
- Live, functional product (checked voxelyo.com returns 200 just now).
- Marked "Offer Free Version" as unclear/:grey_question: rather than yes — the core product is a paid subscription with a 7-day free trial, not a permanent free tier, so I didn't want to overstate it.