### PR TITLE
Add Luphra to Animation & 3D Modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | Name | Title | Description | Offer Free Version |
 |---|---|---|:---:|
 | [Kaedim](http://www.kaedim3d.com) | Magically Generate Custom3D Models in Minutes. | Stop losing hours to modeling tools. Generate stunning 3D art with nothing more than an image. | :x: |
+| [Luphra](https://www.luphra.com/) | Prompt-to-matter: text/sketch to editable 3D. | AI that turns prompts and sketches into editable 3D and manufactured physical products. | :grey_question: |
 | [TextureLab](http://www.texturelab.xyz) | Instant and Unique 3D Textures for Your Next Game. | Generate 3D textures for your game in seconds thanks to AI. | :grey_question: |
 | [lumalabs](https://captures.lumalabs.ai/imagine) | Imagine 3D V1.2 (Alpha). | An early experiment to prototype and create 3D with text Access to generation is gradually expanding to everyone on the waitlist. | :white_check_mark: |
 | [plask](https://plask.ai/) | AI-Powered Mocap Animation Tool. | Easily extract motion from video without expensive bodysuits or motions work. | :white_check_mark: |


### PR DESCRIPTION
## Summary
- Adds [Luphra](https://www.luphra.com/) under ### Animation & 3D Modeling (after Kaedim): prompt-to-matter AI that turns text/sketches into editable 3D and manufactured physical products.

## Test plan
- [ ] Confirm the table row renders correctly in README
- [ ] Confirm link https://www.luphra.com/ works